### PR TITLE
Add service zone to ride requests

### DIFF
--- a/app/api/ride-requests/route.ts
+++ b/app/api/ride-requests/route.ts
@@ -1,0 +1,124 @@
+import { createClient } from "@supabase/supabase-js";
+
+const RIDE_REQUEST_FIELDS =
+  "id, passenger_id, requested_by_user_id, service_zone_id, status, source_address, source_notes, destination_address, destination_notes, return_trip_required, requested_pickup_at, approved_at, assigned_at, started_at, completed_at, rejected_at, rejection_reason";
+
+const VALID_STATUSES = [
+  "pending",
+  "approved",
+  "waiting_for_representitive",
+  "in_progress",
+  "completed",
+  "rejected",
+] as const;
+
+function createSupabaseClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Missing required Supabase environment variable(s)");
+  }
+
+  return createClient(supabaseUrl, supabaseAnonKey);
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const status = searchParams.get("status");
+  const date = searchParams.get("date");
+  const zone = searchParams.get("zone");
+
+  if (status && !VALID_STATUSES.includes(status as (typeof VALID_STATUSES)[number])) {
+    return Response.json(
+      { error: `Invalid status. Must be one of: ${VALID_STATUSES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  if (date && !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return Response.json({ error: "Invalid date format. Use YYYY-MM-DD" }, { status: 400 });
+  }
+
+  const supabase = createSupabaseClient();
+  let query = supabase
+    .from("ride_requests")
+    .select(RIDE_REQUEST_FIELDS)
+    .order("requested_pickup_at", { ascending: false });
+
+  if (status) query = query.eq("status", status);
+
+  if (date) {
+    const start = `${date}T00:00:00.000Z`;
+    const nextDay = new Date(date);
+    nextDay.setDate(nextDay.getDate() + 1);
+    const end = `${nextDay.toISOString().slice(0, 10)}T00:00:00.000Z`;
+    query = query.gte("requested_pickup_at", start).lt("requested_pickup_at", end);
+  }
+
+  if (zone) {
+    query = query.eq("service_zone_id", zone);
+  }
+
+  const { data, error } = await query;
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+  return Response.json(data);
+}
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  const {
+    passenger_id,
+    requested_by_user_id,
+    service_zone_id,
+    source_address,
+    source_notes,
+    destination_address,
+    destination_notes,
+    return_trip_required = false,
+    requested_pickup_at,
+  } = body;
+
+  if (!passenger_id) {
+    return Response.json({ error: "passenger_id is required" }, { status: 400 });
+  }
+  if (!source_address) {
+    return Response.json({ error: "source_address is required" }, { status: 400 });
+  }
+  if (!destination_address) {
+    return Response.json({ error: "destination_address is required" }, { status: 400 });
+  }
+
+  if (requested_pickup_at !== undefined && isNaN(Date.parse(requested_pickup_at))) {
+    return Response.json({ error: "Invalid requested_pickup_at timestamp" }, { status: 400 });
+  }
+
+  const supabase = createSupabaseClient();
+  const { data, error } = await supabase
+    .from("ride_requests")
+    .insert({
+      passenger_id,
+      requested_by_user_id,
+      service_zone_id,
+      source_address,
+      source_notes,
+      destination_address,
+      destination_notes,
+      return_trip_required,
+      requested_pickup_at,
+    })
+    .select(RIDE_REQUEST_FIELDS)
+    .single();
+
+  if (error) {
+    if (error.code === "23503") {
+      return Response.json(
+        { error: "passenger_id, requested_by_user_id, or service_zone_id does not exist" },
+        { status: 400 },
+      );
+    }
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json(data, { status: 201 });
+}

--- a/supabase/ERD.md
+++ b/supabase/ERD.md
@@ -62,6 +62,7 @@ erDiagram
         uuid id PK
         uuid passenger_id FK
         uuid requested_by_user_id FK
+        uuid service_zone_id FK
         request_status status
         text source_address
         text destination_address
@@ -102,6 +103,7 @@ erDiagram
     users ||--|| drivers : profile
     service_zones ||--o{ drivers : covers
     service_zones ||--o{ ambulances : contains
+    service_zones ||--o{ ride_requests : receives
     passengers ||--o{ ride_requests : submits
     ride_requests ||--o{ rides : operational_attempts
     drivers ||--o{ rides : drives

--- a/supabase/migrations/20260511120000_add_service_zone_to_ride_requests.sql
+++ b/supabase/migrations/20260511120000_add_service_zone_to_ride_requests.sql
@@ -1,0 +1,28 @@
+-- Add service-zone ownership to ride requests so API zone filtering can query directly.
+
+begin;
+
+alter table public.ride_requests
+add column if not exists service_zone_id uuid;
+
+do $$
+begin
+	if not exists (
+		select 1
+		from pg_constraint
+		where conname = 'ride_requests_service_zone_id_fkey'
+			and conrelid = 'public.ride_requests'::regclass
+	) then
+		alter table public.ride_requests
+		add constraint ride_requests_service_zone_id_fkey
+		foreign key (service_zone_id)
+		references public.service_zones(id)
+		on delete set null;
+	end if;
+end
+$$;
+
+create index if not exists idx_ride_requests_service_zone_id
+on public.ride_requests (service_zone_id);
+
+commit;


### PR DESCRIPTION
Adds service_zone_id to ride_requests so the ride requests zone filter queries an existing column. Includes a Supabase migration, API updates, and ERD documentation update.\n\nValidation performed locally without touching production:\n- npm run lint\n- ./node_modules/.bin/tsc --noEmit\n- dynamic local route harness for GET zone filtering and POST service_zone_id persistence