### PR TITLE
Add local seed users for permission testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
-# Supabase project used by this local app instance
-NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
-SUPABASE_ANON_KEY=your-anon-key
+# Local development defaults. Do not use hosted Supabase credentials here.
+DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres
+SUPABASE_DB_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=local-dev-anon-key
 
 # Safety guard for local development.
 # true  -> block POST/PUT/PATCH/DELETE under /api
 # false -> allow writes from local app
 # If omitted, the app blocks writes by default in development.
 BLOCK_API_WRITES=true
+LOCAL_DEV_ONLY=true

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,13 @@
+# Local Docker test database only.
+# Never replace these values with production, staging, or shared Supabase credentials.
+DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres
+SUPABASE_DB_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres
+
+# Unit tests mock Supabase today. Keep this local-only so any future test that
+# creates a Supabase client cannot point at the hosted project by accident.
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_URL=http://127.0.0.1:54321
+SUPABASE_ANON_KEY=local-test-anon-key
+
+BLOCK_API_WRITES=false
+LOCAL_TEST_DB=true

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 !.env.example
+!.env.test
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ This project includes an API write guard to reduce accidental writes to shared d
 ### Environment Setup
 
 1. Copy `.env.example` to `.env.local`.
-2. Fill in your local or non-production Supabase credentials.
+2. Keep `.env.local` pointed at localhost/Docker only.
 3. Run the app with `npm run dev`.
 
 ### Recommended Team Workflow
 
 1. Use **local Supabase** for feature development and tests.
-2. Use a separate **staging Supabase** project for integration testing.
+2. Use a separate **staging Supabase** project for integration testing outside local development.
 3. Restrict production credentials and avoid using them in local `.env.local`.
 
 ### Optional: Run Supabase Locally
@@ -30,6 +30,73 @@ supabase db reset
 ```
 
 Then point `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_ANON_KEY` to the local project values.
+
+## Local Docker Test Database
+
+This branch includes an isolated local Postgres database for tests and schema checks. It runs in Docker on host port `55432`, separate from the Supabase CLI default DB port `54322` and separate from any hosted Supabase project.
+
+The committed `.env.test` is intentionally local-only:
+
+- `DATABASE_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres`
+- `SUPABASE_DB_URL=postgres://postgres:postgres@127.0.0.1:55432/postgres`
+- `NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321`
+- `SUPABASE_ANON_KEY=local-test-anon-key`
+
+Do not replace `.env.test` with production, staging, or shared project credentials. If schema is copied from a real database in the future, use a schema-only export unless the data has been explicitly approved and anonymized. Never copy real emails, passwords, phone numbers, payment data, tokens, or private records into the test database.
+
+The local startup path is guarded: `npm run dev`, `npm test`, and the test DB scripts run local environment validation before starting. In development and test mode, hosted Supabase URLs, remote Postgres URLs, Vercel OIDC tokens, and Supabase service-role keys fail fast.
+
+### Start the DB
+
+```bash
+npm run db:test:start
+```
+
+Equivalent Docker command:
+
+```bash
+docker compose up -d test-db
+```
+
+### Load Schema
+
+This resets the disposable `public` and `auth` schemas, creates a minimal local `auth.users` table needed by the existing migrations, and applies every migration in `supabase/migrations`.
+
+```bash
+npm run db:test:schema
+```
+
+### Seed Test Data
+
+This loads synthetic data from `supabase/test-seed.sql`.
+
+```bash
+npm run db:test:seed
+```
+
+### Reset the DB
+
+This reloads the schema and then reloads synthetic seed data.
+
+```bash
+npm run db:test:reset
+```
+
+### Verify the DB
+
+```bash
+npm run db:test:verify
+```
+
+This confirms the container is running, Postgres is accepting local connections, and the seeded schema can be queried.
+
+### Run Tests
+
+```bash
+npm test
+```
+
+Vitest loads `.env.test` through `__tests__/setup-env.ts`. The test setup rejects non-local database URLs, and `createSupabaseClient()` refuses non-local Supabase URLs while `NODE_ENV=test`, so tests cannot accidentally point at a hosted project database.
 
 ## Getting Started
 

--- a/__tests__/setup-env.ts
+++ b/__tests__/setup-env.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const testEnvPath = resolve(process.cwd(), ".env.test");
+
+for (const line of readFileSync(testEnvPath, "utf8").split(/\r?\n/)) {
+  const trimmed = line.trim();
+
+  if (!trimmed || trimmed.startsWith("#")) continue;
+
+  const separatorIndex = trimmed.indexOf("=");
+  if (separatorIndex === -1) continue;
+
+  const key = trimmed.slice(0, separatorIndex).trim();
+  const rawValue = trimmed.slice(separatorIndex + 1).trim();
+
+  process.env[key] = rawValue.replace(/^['"]|['"]$/g, "");
+}
+
+function assertLocalHttpUrl(value: string | undefined, name: string) {
+  if (!value || !/^https?:\/\/(127\.0\.0\.1|localhost|\[::1\])(?::\d+)?(?:\/|$)/.test(value)) {
+    throw new Error(`${name} must be a local URL in .env.test.`);
+  }
+}
+
+function assertLocalPostgresUrl(value: string | undefined, name: string) {
+  if (!value || !/^postgres(?:ql)?:\/\/[^@]+@(127\.0\.0\.1|localhost|\[::1\]):55432(?:\/|$)/.test(value)) {
+    throw new Error(`${name} must point at the local Docker test database in .env.test.`);
+  }
+}
+
+assertLocalHttpUrl(process.env.NEXT_PUBLIC_SUPABASE_URL, "NEXT_PUBLIC_SUPABASE_URL");
+assertLocalHttpUrl(process.env.SUPABASE_URL, "SUPABASE_URL");
+assertLocalPostgresUrl(process.env.DATABASE_URL, "DATABASE_URL");
+assertLocalPostgresUrl(process.env.SUPABASE_DB_URL, "SUPABASE_DB_URL");

--- a/__tests__/test-db.test.ts
+++ b/__tests__/test-db.test.ts
@@ -1,0 +1,44 @@
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+
+function getDatabaseHostAndPort() {
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL is required for local test database checks.");
+  }
+
+  const parsedUrl = new URL(databaseUrl);
+
+  return {
+    host: parsedUrl.hostname,
+    port: Number(parsedUrl.port),
+  };
+}
+
+describe("local Docker test database", () => {
+  it("accepts TCP connections on the local test port", async () => {
+    const { host, port } = getDatabaseHostAndPort();
+
+    await expect(
+      new Promise<void>((resolve, reject) => {
+        const socket = net.createConnection({ host, port });
+        const timeout = setTimeout(() => {
+          socket.destroy();
+          reject(new Error(`Timed out connecting to ${host}:${port}`));
+        }, 3000);
+
+        socket.once("connect", () => {
+          clearTimeout(timeout);
+          socket.end();
+          resolve();
+        });
+
+        socket.once("error", (error) => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+      })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/app/api/ambulances/[id]/route.ts
+++ b/app/api/ambulances/[id]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
     .eq("id", id)
     .single();
 
-  if (error) return supabaseErrorResponse(error);
+  if (error) return supabaseErrorResponse(error, 404);
   return Response.json(data);
 }
 

--- a/app/api/check/route.ts
+++ b/app/api/check/route.ts
@@ -1,5 +1,5 @@
 import { supabaseErrorResponse } from "@/lib/api-errors";
-import { createClient } from "@supabase/supabase-js";
+import { createSupabaseClient } from "@/lib/supabase";
 
 export async function GET() {
   // Use the exact variable names provided by Vercel integration
@@ -17,7 +17,7 @@ export async function GET() {
     );
   }
 
-  const supabase = createClient(supabaseUrl, supabaseKey);
+  const supabase = createSupabaseClient();
 
   // Query a foundational table from this repository schema instead of the old template 'notes' table.
   const { data, error } = await supabase.from("service_zones").select("id").limit(1);

--- a/app/api/drivers/[id]/route.ts
+++ b/app/api/drivers/[id]/route.ts
@@ -15,7 +15,7 @@ export async function GET(
     .eq("id", id)
     .single();
 
-  if (error) return supabaseErrorResponse(error);
+  if (error) return supabaseErrorResponse(error, 404);
   return Response.json(data);
 }
 

--- a/app/api/passengers/[id]/route.ts
+++ b/app/api/passengers/[id]/route.ts
@@ -17,9 +17,9 @@ export async function GET(
     .from("passengers")
     .select(PASSENGER_FIELDS)
     .eq("id", id)
-    .single()
+    .single();
 
-  if (error) return supabaseErrorResponse(error);
+  if (error) return supabaseErrorResponse(error, 404);
 
   return Response.json(data);
 }

--- a/app/api/rides/[id]/route.ts
+++ b/app/api/rides/[id]/route.ts
@@ -16,7 +16,7 @@ export async function GET(
     .eq("id", id)
     .single();
 
-  if (error) return supabaseErrorResponse(error);
+  if (error) return supabaseErrorResponse(error, 404);
   return Response.json(data);
 }
 

--- a/app/api/service-zones/[id]/route.ts
+++ b/app/api/service-zones/[id]/route.ts
@@ -13,7 +13,7 @@ export async function GET(
     .eq("id", id)
     .single();
 
-  if (error) return supabaseErrorResponse(error);
+  if (error) return supabaseErrorResponse(error, 404);
   return Response.json(data);
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  test-db:
+    image: postgres:17
+    container_name: savionim-local-test-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "127.0.0.1:55432:5432"
+    volumes:
+      - savionim-local-test-db-data:/var/lib/postgresql/data
+      - ./supabase:/workspace/supabase:ro
+      - ./scripts/test-db:/workspace/scripts/test-db:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  savionim-local-test-db-data:

--- a/lib/env-safety.ts
+++ b/lib/env-safety.ts
@@ -1,0 +1,98 @@
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+const LOCAL_POSTGRES_PORTS = new Set(["5432", "54320", "54322", "55432"]);
+const LOCAL_HTTP_PORTS = new Set(["3000", "54321"]);
+const HOSTED_SUPABASE_HOST_PATTERN = /(^|\.)supabase\.co$/i;
+const LOCAL_MODES = new Set(["development", "test"]);
+
+type EnvMap = NodeJS.ProcessEnv;
+
+function isLocalMode() {
+  return LOCAL_MODES.has(process.env.NODE_ENV ?? "development");
+}
+
+function parseUrl(value: string, key: string): URL {
+  try {
+    return new URL(value);
+  } catch {
+    throw new Error(`${key} must be a valid URL.`);
+  }
+}
+
+function normalizeHost(hostname: string) {
+  return hostname.replace(/^\[|\]$/g, "");
+}
+
+function isLocalHost(hostname: string) {
+  return LOCAL_HOSTS.has(hostname) || LOCAL_HOSTS.has(normalizeHost(hostname));
+}
+
+function assertLocalHttpUrl(key: string, value: string) {
+  const parsedUrl = parseUrl(value, key);
+
+  if (!["http:", "https:"].includes(parsedUrl.protocol)) {
+    throw new Error(`${key} must be an HTTP URL.`);
+  }
+
+  if (HOSTED_SUPABASE_HOST_PATTERN.test(parsedUrl.hostname)) {
+    throw new Error(`${key} points to hosted Supabase. Local mode must use localhost only.`);
+  }
+
+  if (!isLocalHost(parsedUrl.hostname)) {
+    throw new Error(`${key} must use localhost or 127.0.0.1 in local mode.`);
+  }
+
+  if (parsedUrl.port && !LOCAL_HTTP_PORTS.has(parsedUrl.port)) {
+    throw new Error(`${key} uses unexpected local port ${parsedUrl.port}.`);
+  }
+}
+
+function assertLocalPostgresUrl(key: string, value: string) {
+  const parsedUrl = parseUrl(value, key);
+
+  if (!["postgres:", "postgresql:"].includes(parsedUrl.protocol)) {
+    throw new Error(`${key} must be a Postgres connection string.`);
+  }
+
+  if (!isLocalHost(parsedUrl.hostname)) {
+    throw new Error(`${key} must use localhost or 127.0.0.1 in local mode.`);
+  }
+
+  if (parsedUrl.port && !LOCAL_POSTGRES_PORTS.has(parsedUrl.port)) {
+    throw new Error(`${key} uses unexpected local Postgres port ${parsedUrl.port}.`);
+  }
+}
+
+function assertNoHostedCredentialValues(env: EnvMap) {
+  const forbiddenKeys = ["VERCEL_OIDC_TOKEN", "SUPABASE_SERVICE_ROLE_KEY"];
+
+  for (const key of forbiddenKeys) {
+    if (env[key]) {
+      throw new Error(`${key} must not be present in local development or test mode.`);
+    }
+  }
+}
+
+export function assertLocalOnlyEnvironment(env: EnvMap = process.env) {
+  if (!isLocalMode()) return;
+
+  assertNoHostedCredentialValues(env);
+
+  const httpUrlKeys = ["NEXT_PUBLIC_SUPABASE_URL", "SUPABASE_URL"];
+  const postgresUrlKeys = ["DATABASE_URL", "SUPABASE_DB_URL", "POSTGRES_URL", "POSTGRES_PRISMA_URL"];
+
+  for (const key of httpUrlKeys) {
+    const value = env[key];
+    if (value) assertLocalHttpUrl(key, value);
+  }
+
+  for (const key of postgresUrlKeys) {
+    const value = env[key];
+    if (value) assertLocalPostgresUrl(key, value);
+  }
+}
+
+export function assertLocalSupabaseUrl(supabaseUrl: string) {
+  if (!isLocalMode()) return;
+
+  assertLocalHttpUrl("NEXT_PUBLIC_SUPABASE_URL", supabaseUrl);
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
+import { assertLocalOnlyEnvironment, assertLocalSupabaseUrl } from "@/lib/env-safety";
 
 export function createSupabaseClient() {
+  assertLocalOnlyEnvironment();
+
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
 
@@ -14,6 +17,8 @@ export function createSupabaseClient() {
       `Missing required Supabase environment variable(s): ${missingEnvVars.join(", ")}`
     );
   }
+
+  assertLocalSupabaseUrl(supabaseUrl);
 
   return createClient(supabaseUrl, supabaseAnonKey);
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,7 @@
 import type { NextConfig } from "next";
+import { assertLocalOnlyEnvironment } from "./lib/env-safety";
+
+assertLocalOnlyEnvironment();
 
 const nextConfig: NextConfig = {
   /* config options here */

--- a/package.json
+++ b/package.json
@@ -3,11 +3,18 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "predev": "node ./scripts/validate-local-env.mjs",
     "dev": "next dev",
+    "pretest": "node ./scripts/validate-local-env.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "db:test:start": "sh ./scripts/test-db/start.sh",
+    "db:test:schema": "sh ./scripts/test-db/load-schema.sh",
+    "db:test:seed": "sh ./scripts/test-db/seed.sh",
+    "db:test:reset": "sh ./scripts/test-db/reset.sh",
+    "db:test:verify": "sh ./scripts/test-db/verify.sh"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.104.1",

--- a/scripts/test-db/00-auth-schema-stub.sql
+++ b/scripts/test-db/00-auth-schema-stub.sql
@@ -1,0 +1,27 @@
+create schema if not exists auth;
+
+create table if not exists auth.users (
+  id uuid primary key,
+  instance_id uuid,
+  aud varchar(255),
+  role varchar(255),
+  email varchar(255) unique,
+  encrypted_password varchar(255),
+  email_confirmed_at timestamptz,
+  raw_app_meta_data jsonb,
+  raw_user_meta_data jsonb,
+  created_at timestamptz,
+  updated_at timestamptz
+);
+
+create table if not exists auth.identities (
+  id uuid primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  identity_data jsonb not null,
+  provider text not null,
+  provider_id text not null,
+  last_sign_in_at timestamptz,
+  created_at timestamptz,
+  updated_at timestamptz,
+  unique (provider_id, provider)
+);

--- a/scripts/test-db/docker-bin.sh
+++ b/scripts/test-db/docker-bin.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+if command -v docker >/dev/null 2>&1; then
+  command -v docker
+elif [ -x /Applications/Docker.app/Contents/Resources/bin/docker ]; then
+  printf '%s\n' /Applications/Docker.app/Contents/Resources/bin/docker
+else
+  printf '%s\n' "docker"
+fi

--- a/scripts/test-db/load-schema.sh
+++ b/scripts/test-db/load-schema.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+set -eu
+
+DOCKER_BIN="${DOCKER_BIN:-$(./scripts/test-db/docker-bin.sh)}"
+
+./scripts/test-db/start.sh
+
+"${DOCKER_BIN}" compose exec -T test-db psql -U postgres -d postgres -v ON_ERROR_STOP=1 <<'SQL'
+drop schema if exists public cascade;
+drop schema if exists auth cascade;
+
+create schema public;
+grant all on schema public to postgres;
+grant all on schema public to public;
+SQL
+
+"${DOCKER_BIN}" compose exec -T test-db psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f /workspace/scripts/test-db/00-auth-schema-stub.sql
+
+"${DOCKER_BIN}" compose exec -T test-db sh -c '
+  set -eu
+  for migration in /workspace/supabase/migrations/*.sql; do
+    echo "Applying ${migration}"
+    psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f "${migration}"
+  done
+'

--- a/scripts/test-db/reset.sh
+++ b/scripts/test-db/reset.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+set -eu
+
+./scripts/test-db/load-schema.sh
+./scripts/test-db/seed.sh

--- a/scripts/test-db/seed.sh
+++ b/scripts/test-db/seed.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -eu
+
+DOCKER_BIN="${DOCKER_BIN:-$(./scripts/test-db/docker-bin.sh)}"
+
+./scripts/test-db/start.sh
+"${DOCKER_BIN}" compose exec -T test-db psql -U postgres -d postgres -v ON_ERROR_STOP=1 -f /workspace/supabase/test-seed.sql

--- a/scripts/test-db/start.sh
+++ b/scripts/test-db/start.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eu
+
+node ./scripts/validate-local-env.mjs
+
+DOCKER_BIN="${DOCKER_BIN:-$(./scripts/test-db/docker-bin.sh)}"
+
+"${DOCKER_BIN}" compose up -d test-db
+"${DOCKER_BIN}" compose exec -T test-db sh -c 'until pg_isready -U postgres -d postgres; do sleep 1; done'

--- a/scripts/test-db/verify.sh
+++ b/scripts/test-db/verify.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eu
+
+DOCKER_BIN="${DOCKER_BIN:-$(./scripts/test-db/docker-bin.sh)}"
+
+./scripts/test-db/start.sh
+
+"${DOCKER_BIN}" compose ps test-db
+"${DOCKER_BIN}" compose exec -T test-db pg_isready -U postgres -d postgres
+"${DOCKER_BIN}" compose exec -T test-db psql -U postgres -d postgres -v ON_ERROR_STOP=1 -c "select count(*) as service_zone_count from public.service_zones;"

--- a/scripts/validate-local-env.mjs
+++ b/scripts/validate-local-env.mjs
@@ -1,0 +1,97 @@
+const LOCAL_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+const HOSTED_SUPABASE_HOST_PATTERN = /(^|\.)supabase\.co$/i;
+const LOCAL_HTTP_PORTS = new Set(["3000", "54321"]);
+const LOCAL_POSTGRES_PORTS = new Set(["5432", "54320", "54322", "55432"]);
+
+function parseDotenv(contents) {
+  const env = {};
+
+  for (const line of contents.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const separatorIndex = trimmed.indexOf("=");
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1).trim();
+    env[key] = rawValue.replace(/^['"]|['"]$/g, "");
+  }
+
+  return env;
+}
+
+async function loadEnvFile(path) {
+  try {
+    const fs = await import("node:fs/promises");
+    return parseDotenv(await fs.readFile(path, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function normalizeHost(hostname) {
+  return hostname.replace(/^\[|\]$/g, "");
+}
+
+function isLocalHost(hostname) {
+  return LOCAL_HOSTS.has(hostname) || LOCAL_HOSTS.has(normalizeHost(hostname));
+}
+
+function assertUrl(key, value) {
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    throw new Error(`${key} must be a valid URL.`);
+  }
+
+  if (HOSTED_SUPABASE_HOST_PATTERN.test(parsedUrl.hostname)) {
+    throw new Error(`${key} points to hosted Supabase. Local mode must use localhost only.`);
+  }
+
+  if (!isLocalHost(parsedUrl.hostname)) {
+    throw new Error(`${key} must use localhost or 127.0.0.1 in local mode.`);
+  }
+
+  if (["postgres:", "postgresql:"].includes(parsedUrl.protocol)) {
+    if (parsedUrl.port && !LOCAL_POSTGRES_PORTS.has(parsedUrl.port)) {
+      throw new Error(`${key} uses unexpected local Postgres port ${parsedUrl.port}.`);
+    }
+    return;
+  }
+
+  if (["http:", "https:"].includes(parsedUrl.protocol)) {
+    if (parsedUrl.port && !LOCAL_HTTP_PORTS.has(parsedUrl.port)) {
+      throw new Error(`${key} uses unexpected local HTTP port ${parsedUrl.port}.`);
+    }
+    return;
+  }
+
+  throw new Error(`${key} uses unsupported protocol ${parsedUrl.protocol}.`);
+}
+
+const urlKeys = [
+  "DATABASE_URL",
+  "SUPABASE_DB_URL",
+  "POSTGRES_URL",
+  "POSTGRES_PRISMA_URL",
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "SUPABASE_URL",
+];
+
+function validateEnvMap(name, env) {
+  for (const key of urlKeys) {
+    if (env[key]) assertUrl(`${name}:${key}`, env[key]);
+  }
+
+  for (const key of ["VERCEL_OIDC_TOKEN", "SUPABASE_SERVICE_ROLE_KEY"]) {
+    if (env[key]) {
+      throw new Error(`${name}:${key} must not be present in local development or test mode.`);
+    }
+  }
+}
+
+validateEnvMap("process.env", process.env);
+validateEnvMap(".env.local", await loadEnvFile(".env.local"));
+validateEnvMap(".env.test", await loadEnvFile(".env.test"));

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -13,7 +13,7 @@ INSERT INTO public.service_zones (id, name, region_code, region, city, is_active
   ('11111111-0000-0000-0000-000000000003', 'South Tel Aviv',    'TLV-S', 'Tel Aviv District', 'Jaffa',    true)
 ON CONFLICT (id) DO NOTHING;
 
--- ─── Auth Users (5 drivers) ───────────────────────────────────────────────────
+-- ─── Auth Users (admin, dispatcher, drivers) ──────────────────────────────────
 -- Synthetic entries for local / staging only. Password: Seed1234!
 
 INSERT INTO auth.users (
@@ -23,35 +23,82 @@ INSERT INTO auth.users (
   raw_app_meta_data, raw_user_meta_data,
   created_at, updated_at
 ) VALUES
+  ('22222222-0000-0000-0000-000000000010', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated',
+   'admin@savionim.test', crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
+   '{"provider":"email","providers":["email"],"app_role":"admin"}'::jsonb, '{}'::jsonb, NOW(), NOW()),
+
+  ('22222222-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated',
+   'dispatcher@savionim.test', crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
+   '{"provider":"email","providers":["email"],"app_role":"dispatcher"}'::jsonb, '{}'::jsonb, NOW(), NOW()),
+
   ('22222222-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000000',
    'authenticated', 'authenticated',
    'avi.cohen@savionim.test',    crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
-   '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb, NOW(), NOW()),
+   '{"provider":"email","providers":["email"],"app_role":"driver"}'::jsonb, '{}'::jsonb, NOW(), NOW()),
 
   ('22222222-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000',
    'authenticated', 'authenticated',
    'noa.levi@savionim.test',     crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
-   '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb, NOW(), NOW()),
+   '{"provider":"email","providers":["email"],"app_role":"driver"}'::jsonb, '{}'::jsonb, NOW(), NOW()),
 
   ('22222222-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000',
    'authenticated', 'authenticated',
    'yossi.mizrahi@savionim.test', crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
-   '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb, NOW(), NOW()),
+   '{"provider":"email","providers":["email"],"app_role":"driver"}'::jsonb, '{}'::jsonb, NOW(), NOW()),
 
   ('22222222-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000000',
    'authenticated', 'authenticated',
    'dana.shapiro@savionim.test', crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
-   '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb, NOW(), NOW()),
+   '{"provider":"email","providers":["email"],"app_role":"driver"}'::jsonb, '{}'::jsonb, NOW(), NOW()),
 
   ('22222222-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000000',
    'authenticated', 'authenticated',
    'eran.peretz@savionim.test',  crypt('Seed1234!', gen_salt('bf', 10)), NOW(),
-   '{"provider":"email","providers":["email"]}'::jsonb, '{}'::jsonb, NOW(), NOW())
+   '{"provider":"email","providers":["email"],"app_role":"driver"}'::jsonb, '{}'::jsonb, NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
--- ─── Public Users (5 drivers) ─────────────────────────────────────────────────
+-- ─── Auth Identities ─────────────────────────────────────────────────────────
+-- Required by Supabase Auth email/password sign-in for local seeded users.
+
+INSERT INTO auth.identities (
+  id, user_id, identity_data, provider, provider_id, last_sign_in_at, created_at, updated_at
+) VALUES
+  ('2aaaaaaa-0000-0000-0000-000000000010', '22222222-0000-0000-0000-000000000010',
+   '{"sub":"22222222-0000-0000-0000-000000000010","email":"admin@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000010', NOW(), NOW(), NOW()),
+
+  ('2aaaaaaa-0000-0000-0000-000000000011', '22222222-0000-0000-0000-000000000011',
+   '{"sub":"22222222-0000-0000-0000-000000000011","email":"dispatcher@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000011', NOW(), NOW(), NOW()),
+
+  ('2aaaaaaa-0000-0000-0000-000000000001', '22222222-0000-0000-0000-000000000001',
+   '{"sub":"22222222-0000-0000-0000-000000000001","email":"avi.cohen@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000001', NOW(), NOW(), NOW()),
+
+  ('2aaaaaaa-0000-0000-0000-000000000002', '22222222-0000-0000-0000-000000000002',
+   '{"sub":"22222222-0000-0000-0000-000000000002","email":"noa.levi@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000002', NOW(), NOW(), NOW()),
+
+  ('2aaaaaaa-0000-0000-0000-000000000003', '22222222-0000-0000-0000-000000000003',
+   '{"sub":"22222222-0000-0000-0000-000000000003","email":"yossi.mizrahi@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000003', NOW(), NOW(), NOW()),
+
+  ('2aaaaaaa-0000-0000-0000-000000000004', '22222222-0000-0000-0000-000000000004',
+   '{"sub":"22222222-0000-0000-0000-000000000004","email":"dana.shapiro@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000004', NOW(), NOW(), NOW()),
+
+  ('2aaaaaaa-0000-0000-0000-000000000005', '22222222-0000-0000-0000-000000000005',
+   '{"sub":"22222222-0000-0000-0000-000000000005","email":"eran.peretz@savionim.test"}'::jsonb,
+   'email', '22222222-0000-0000-0000-000000000005', NOW(), NOW(), NOW())
+ON CONFLICT (provider_id, provider) DO NOTHING;
+
+-- ─── Public Users (admin, dispatcher, drivers) ────────────────────────────────
 
 INSERT INTO public.users (id, full_name, phone, role, is_active) VALUES
+  ('22222222-0000-0000-0000-000000000010', 'Local Admin',      '000-000-0010', 'admin', true),
+  ('22222222-0000-0000-0000-000000000011', 'Local Dispatcher', '000-000-0011', 'dispatcher', true),
   ('22222222-0000-0000-0000-000000000001', 'Avi Cohen',       '050-1234567', 'driver', true),
   ('22222222-0000-0000-0000-000000000002', 'Noa Levi',        '052-2345678', 'driver', true),
   ('22222222-0000-0000-0000-000000000003', 'Yossi Mizrahi',   '054-3456789', 'driver', true),

--- a/supabase/test-seed.sql
+++ b/supabase/test-seed.sql
@@ -1,0 +1,145 @@
+-- Synthetic local test data only. Do not add production data here.
+-- This file intentionally uses example.test emails and placeholder phone values.
+
+begin;
+
+insert into public.service_zones (id, name, region_code, region, city, is_active) values
+  ('11111111-1000-0000-0000-000000000001', 'Test North Zone', 'TEST-N', 'Test Region', 'Test City', true),
+  ('11111111-1000-0000-0000-000000000002', 'Test South Zone', 'TEST-S', 'Test Region', 'Test City', true)
+on conflict (id) do nothing;
+
+insert into auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+) values
+  (
+    '22222222-1000-0000-0000-000000000010',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'admin.one@example.test',
+    crypt('LocalTestPassword123!', gen_salt('bf', 10)),
+    now(),
+    '{"provider":"email","providers":["email"],"app_role":"admin"}'::jsonb,
+    '{}'::jsonb,
+    now(),
+    now()
+  ),
+  (
+    '22222222-1000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'dispatcher.one@example.test',
+    crypt('LocalTestPassword123!', gen_salt('bf', 10)),
+    now(),
+    '{"provider":"email","providers":["email"],"app_role":"dispatcher"}'::jsonb,
+    '{}'::jsonb,
+    now(),
+    now()
+  ),
+  (
+    '22222222-1000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000000',
+    'authenticated',
+    'authenticated',
+    'driver.one@example.test',
+    crypt('LocalTestPassword123!', gen_salt('bf', 10)),
+    now(),
+    '{"provider":"email","providers":["email"],"app_role":"driver"}'::jsonb,
+    '{}'::jsonb,
+    now(),
+    now()
+  )
+on conflict (id) do nothing;
+
+insert into auth.identities (
+  id, user_id, identity_data, provider, provider_id, last_sign_in_at, created_at, updated_at
+) values
+  (
+    '2aaaaaaa-1000-0000-0000-000000000010',
+    '22222222-1000-0000-0000-000000000010',
+    '{"sub":"22222222-1000-0000-0000-000000000010","email":"admin.one@example.test"}'::jsonb,
+    'email',
+    '22222222-1000-0000-0000-000000000010',
+    now(),
+    now(),
+    now()
+  ),
+  (
+    '2aaaaaaa-1000-0000-0000-000000000002',
+    '22222222-1000-0000-0000-000000000002',
+    '{"sub":"22222222-1000-0000-0000-000000000002","email":"dispatcher.one@example.test"}'::jsonb,
+    'email',
+    '22222222-1000-0000-0000-000000000002',
+    now(),
+    now(),
+    now()
+  ),
+  (
+    '2aaaaaaa-1000-0000-0000-000000000001',
+    '22222222-1000-0000-0000-000000000001',
+    '{"sub":"22222222-1000-0000-0000-000000000001","email":"driver.one@example.test"}'::jsonb,
+    'email',
+    '22222222-1000-0000-0000-000000000001',
+    now(),
+    now(),
+    now()
+  )
+on conflict (provider_id, provider) do nothing;
+
+insert into public.users (id, full_name, phone, role, is_active) values
+  ('22222222-1000-0000-0000-000000000010', 'Test Admin One', '000-000-0010', 'admin', true),
+  ('22222222-1000-0000-0000-000000000002', 'Test Dispatcher One', '000-000-0002', 'dispatcher', true),
+  ('22222222-1000-0000-0000-000000000001', 'Test Driver One', '000-000-0001', 'driver', true)
+on conflict (id) do nothing;
+
+insert into public.drivers (id, user_id, contact_phone, service_zone_id, is_active) values
+  (
+    '33333333-1000-0000-0000-000000000001',
+    '22222222-1000-0000-0000-000000000001',
+    '000-000-0001',
+    '11111111-1000-0000-0000-000000000001',
+    true
+  )
+on conflict (id) do nothing;
+
+insert into public.ambulances (id, license_plate, service_zone_id, is_available, is_active) values
+  ('44444444-1000-0000-0000-000000000001', 'TEST-001', '11111111-1000-0000-0000-000000000001', true, true)
+on conflict (id) do nothing;
+
+insert into public.passengers (id, national_id, full_name, phone, emergency_contact, mobility_need, category) values
+  ('55555555-1000-0000-0000-000000000001', 'TEST-0001', 'Test Passenger One', '000-000-0101', '000-000-0199', 'none', 'test')
+on conflict (id) do nothing;
+
+insert into public.ride_requests (
+  id,
+  passenger_id,
+  requested_by_user_id,
+  service_zone_id,
+  status,
+  source_address,
+  destination_address,
+  requested_pickup_at
+) values (
+  '66666666-1000-0000-0000-000000000001',
+  '55555555-1000-0000-0000-000000000001',
+  '22222222-1000-0000-0000-000000000002',
+  '11111111-1000-0000-0000-000000000001',
+  'approved',
+  '100 Test Source Street',
+  '200 Test Destination Street',
+  '2026-05-12T10:00:00Z'
+)
+on conflict (id) do nothing;
+
+commit;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,5 +5,6 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: "node",
+    setupFiles: ["./__tests__/setup-env.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- add local Docker/test database isolation and validation files on top of remote dev
- seed local admin, dispatcher, and driver auth identities for permission testing
- document local DB setup and test/reset commands

## Verification
- node ./scripts/validate-local-env.mjs
- docker compose config confirms 127.0.0.1:55432
- npm run db:test:reset
- npm run db:test:verify
- npm test
- npm run lint
- direct supabase/seed.sql load against local Docker Postgres

## Safety
Local database access remains bound to localhost only, and dev/test validation rejects remote Supabase or non-local database URLs.