### PR TITLE
fix(supabase): use default invite email template for free-tier deploy

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -238,9 +238,13 @@ otp_expiry = 86400
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 
-[auth.email.template.invite]
-subject = "Complete your Savionim registration"
-content_path = "./supabase/templates/invite.html"
+# Custom invite email template is disabled: free-tier projects on the default
+# email provider can't modify email templates (Supabase deploy returns 400).
+# Invites (auth.admin.inviteUserByEmail) fall back to Supabase's default invite
+# email. To re-enable a branded template, configure [auth.email.smtp] first.
+# [auth.email.template.invite]
+# subject = "Complete your Savionim registration"
+# content_path = "./supabase/templates/invite.html"
 
 # Uncomment to customize notification email template
 # [auth.email.notification.password_changed]


### PR DESCRIPTION
Comment out [auth.email.template.invite] so config deploys don't 400 on a free-tier project using the default email provider. Invites (auth.admin.inviteUserByEmail) fall back to Supabase's default invite email; the link/onboarding flow is unchanged. Re-enable with custom SMTP if branded invite emails are needed.